### PR TITLE
Prevent utf8 (e.g. emoji) breaking export

### DIFF
--- a/exportBooks.py
+++ b/exportBooks.py
@@ -42,7 +42,7 @@ for book in books_data_data:
 
     book_html = requests.get(export_url, headers=header, verify=cert_verify_url)
     with open(export_file_name, "w+") as file:
-        file.write(book_html.text)
+        file.write(book_html.text.encode('utf8'))
 
     print("Successfully exported book {}".format(book['name']))
 


### PR DESCRIPTION
Before this change would fail with 
```
Traceback (most recent call last):
  File "exportBooks.py", line 44, in <module>
    file.write(book_html.text)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xa3' in position 55669: ordinal not in range(128)
```